### PR TITLE
chore(repo): rename @faketube/* packages to @codetube/*

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Open-source YouTube clone. Monorepo using npm workspaces.
 
 ```
 .
-├── web/      Next.js 15 web app (@faketube/web)
-├── docs/     Nextra v4 docs and blog site (@faketube/docs)
-├── cloud/    AWS CDK infrastructure (@faketube/cloud)
+├── web/      Next.js 15 web app (@codetube/web)
+├── docs/     Nextra v4 docs and blog site (@codetube/docs)
+├── cloud/    AWS CDK infrastructure (@codetube/cloud)
 └── data/     seed data
 
 Gherkin specifications live under `docs/content/specs/` and render at /specs.

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -1,6 +1,6 @@
-# @faketube/cloud
+# @codetube/cloud
 
-AWS CDK infrastructure for FakeTube. `@faketube/cloud` workspace of the FakeTube monorepo.
+AWS CDK infrastructure for FakeTube. `@codetube/cloud` workspace of the FakeTube monorepo.
 
 The `cdk.json` file tells the CDK Toolkit how to execute the app.
 

--- a/cloud/package.json
+++ b/cloud/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@faketube/cloud",
+  "name": "@codetube/cloud",
   "version": "0.1.0",
   "private": true,
   "bin": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@faketube/docs",
+  "name": "@codetube/docs",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "faketube-monorepo",
+  "name": "codetube-monorepo",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "faketube-monorepo",
+      "name": "codetube-monorepo",
       "version": "0.0.0",
       "workspaces": [
         "web",
@@ -14,7 +14,7 @@
       ]
     },
     "cloud": {
-      "name": "@faketube/cloud",
+      "name": "@codetube/cloud",
       "version": "0.1.0",
       "dependencies": {
         "@aws-lambda-powertools/logger": "^2.25.1",
@@ -49,7 +49,7 @@
       }
     },
     "docs": {
-      "name": "@faketube/docs",
+      "name": "@codetube/docs",
       "version": "0.1.0",
       "dependencies": {
         "next": "15.3.1",
@@ -1454,6 +1454,18 @@
       "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
       "license": "Apache-2.0"
     },
+    "node_modules/@codetube/cloud": {
+      "resolved": "cloud",
+      "link": true
+    },
+    "node_modules/@codetube/docs": {
+      "resolved": "docs",
+      "link": true
+    },
+    "node_modules/@codetube/web": {
+      "resolved": "web",
+      "link": true
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -2242,18 +2254,6 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
-    },
-    "node_modules/@faketube/cloud": {
-      "resolved": "cloud",
-      "link": true
-    },
-    "node_modules/@faketube/docs": {
-      "resolved": "docs",
-      "link": true
-    },
-    "node_modules/@faketube/web": {
-      "resolved": "web",
-      "link": true
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
@@ -18172,7 +18172,7 @@
       }
     },
     "web": {
-      "name": "@faketube/web",
+      "name": "@codetube/web",
       "version": "0.1.0",
       "dependencies": {
         "@emotion/cache": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "faketube-monorepo",
+  "name": "codetube-monorepo",
   "private": true,
   "version": "0.0.0",
   "workspaces": [

--- a/web/README.md
+++ b/web/README.md
@@ -1,4 +1,4 @@
-This is a [Next.js](https://nextjs.org) project. It is the `@faketube/web` workspace of the FakeTube monorepo.
+This is a [Next.js](https://nextjs.org) project. It is the `@codetube/web` workspace of the FakeTube monorepo.
 
 ## Getting Started
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@faketube/web",
+  "name": "@codetube/web",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Renames the npm scope on all three workspace packages ahead of the CodeTube rebrand. **Package-name change only** — the project brand (repo name, README copy referencing "FakeTube", etc.) is renamed in PR #8.

| File | From | To |
|---|---|---|
| `web/package.json` | `@faketube/web` | `@codetube/web` |
| `docs/package.json` | `@faketube/docs` | `@codetube/docs` |
| `cloud/package.json` | `@faketube/cloud` | `@codetube/cloud` |
| `package.json` (root) | `faketube-monorepo` | `codetube-monorepo` |

README scope mentions (the `@faketube/<pkg>` references) updated to match. Brand mentions ("FakeTube monorepo", "AWS CDK infrastructure for FakeTube") deliberately kept as-is — they ship in PR #8.

No workspace currently depends on another via the `@<scope>/<pkg>` specifier, so no cross-workspace import sites needed updating.

## Test plan

- [x] `npm install` at root succeeds, produces `node_modules/@codetube/{web,docs,cloud}` symlinks; no leftover `@faketube/` directory
- [x] `npm test -w cloud` passes
- [x] `npm run lint -w web` reports no errors (logs as `@codetube/web@0.1.0`)
- [x] `npm run build -w docs` prerenders all 23 routes
- [x] Reviewer: pull branch, `npm install`, confirm dev server boots: `npm run dev -w web` and `npm run dev -w docs`

This is PR #7 of the monorepo restructure series (#20, #21, #23, #24, #25, #26).