### PR TITLE
feat(docs): render frontmatter title as H1 at the top of each page

### DIFF
--- a/docs/app/[...mdxPath]/page.tsx
+++ b/docs/app/[...mdxPath]/page.tsx
@@ -28,8 +28,10 @@ export default async function Page(props: PageProps) {
   const { default: MDXContent, toc, metadata, sourceCode } = await importPage(
     params.mdxPath
   )
+  const title = (metadata as { title?: string } | undefined)?.title
   return (
     <Wrapper toc={toc} metadata={metadata} sourceCode={sourceCode}>
+      {title && <h1 className="ct-page-title">{title}</h1>}
       <MDXContent {...props} params={params} />
     </Wrapper>
   )

--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -20,6 +20,16 @@ body > [class*="bg-gray-100"] {
   margin-top: auto;
 }
 
+/* Page title (rendered by the catch-all from frontmatter) --------------- */
+
+.ct-page-title {
+  font-size: clamp(1.875rem, 4vw, 2.5rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  margin: 0 0 1.5rem 0;
+}
+
 /* Footer content -------------------------------------------------------- */
 
 .ct-footer-inner {

--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -15,6 +15,14 @@ body {
   min-height: 100vh;
 }
 
+/* Fix: body flex column + mx-auto on Nextra's content wrapper causes
+   shrink-wrapping instead of stretching. Force full width so auto
+   margins just center the max-width, not shrink the element. */
+body > div,
+body > main {
+  width: 100%;
+}
+
 /* Push Nextra's footer wrapper to the bottom of the viewport on short pages */
 body > [class*="bg-gray-100"] {
   margin-top: auto;

--- a/docs/content/blog/index.mdx
+++ b/docs/content/blog/index.mdx
@@ -2,7 +2,5 @@
 title: Blog
 ---
 
-# Blog
-
 Articles from the [dev.to series](https://dev.to/jacekkosciesza/series/22439)
 will land here. Each post gets its own MDX file under `content/blog/`.

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -3,8 +3,6 @@ title: Overview
 asIndexPage: true
 ---
 
-# Documentation
-
 Welcome to the CodeTube documentation.
 
 This section will host technical docs and BDD specifications. The empty

--- a/docs/content/docs/specs/components.mdx
+++ b/docs/content/docs/specs/components.mdx
@@ -2,8 +2,6 @@
 title: Components
 ---
 
-# Components
-
 Component tree for the application.
 
 ```yaml

--- a/docs/content/docs/specs/index.mdx
+++ b/docs/content/docs/specs/index.mdx
@@ -2,6 +2,4 @@
 title: Specifications
 ---
 
-# Specifications
-
 Gherkin feature specifications and the component tree for CodeTube. These describe expected behaviour at the user-flow level.


### PR DESCRIPTION
## Summary

Articles previously had only the breadcrumb at the top of the content area — no big page title. This adds the frontmatter \`title\` as an \`<h1>\` right above the MDX body in the catch-all route, so every content page gets a consistent title heading.

| Page type | Title rendered as H1 |
|---|---|
| Blog article | _"Build YouTube Clone with AWS - CodeTube #0"_ etc. |
| Blog index (\`/blog\`) | _"Blog"_ |
| Docs index (\`/docs\`) | _"Overview"_ |
| Specs index (\`/docs/specs\`) | _"Specifications"_ |
| Spec leaf | _"Masthead"_, _"App Drawer"_, etc. |

## Changes

- \`app/[...mdxPath]/page.tsx\`: extract \`metadata.title\` from \`importPage()\` and render \`<h1 className=\"ct-page-title\">{title}</h1>\` before \`MDXContent\`.
- \`app/globals.css\`: add \`.ct-page-title\` styles (clamp font-size 1.875–2.5rem, weight 800, tight letter-spacing, 1.5rem bottom margin).
- Removed the now-redundant \`# Heading\` from the four MDX files whose body started with a heading matching the frontmatter:
  - \`content/docs/index.mdx\` (was \`# Documentation\`)
  - \`content/docs/specs/index.mdx\` (was \`# Specifications\`)
  - \`content/docs/specs/components.mdx\` (was \`# Components\`)
  - \`content/blog/index.mdx\` (was \`# Blog\`)

## Test plan

- [x] \`npm run build -w docs\` succeeds (24 routes)
- [x] Playwright probe confirms every page type renders **exactly one** H1 with class \`ct-page-title\` matching the frontmatter title — no duplicates
- [ ] Reviewer: pull branch, \`npm run dev -w docs\`, click through an article, the blog index, and a spec page — confirm each shows a big title heading at the top with sensible spacing