### PR TITLE
feat(docs): blog index card grid with cover images

### DIFF
--- a/docs/app/[...mdxPath]/page.tsx
+++ b/docs/app/[...mdxPath]/page.tsx
@@ -28,10 +28,12 @@ export default async function Page(props: PageProps) {
   const { default: MDXContent, toc, metadata, sourceCode } = await importPage(
     params.mdxPath
   )
-  const title = (metadata as { title?: string } | undefined)?.title
+  const meta = metadata as { title?: string; hideTitle?: boolean } | undefined
   return (
     <Wrapper toc={toc} metadata={metadata} sourceCode={sourceCode}>
-      {title && <h1 className="ct-page-title">{title}</h1>}
+      {meta?.title && !meta.hideTitle && (
+        <h1 className="ct-page-title">{meta.title}</h1>
+      )}
       <MDXContent {...props} params={params} />
     </Wrapper>
   )

--- a/docs/app/_components/BlogCards.tsx
+++ b/docs/app/_components/BlogCards.tsx
@@ -1,0 +1,53 @@
+import { getPageMap } from 'nextra/page-map'
+
+type PageItem = {
+  name: string
+  route: string
+  frontMatter?: {
+    title?: string
+    date?: string
+    description?: string
+    cover?: string
+    readingTime?: number
+  }
+}
+
+export async function BlogCards() {
+  const pageMap = (await getPageMap('/blog')) as PageItem[]
+
+  const articles = pageMap.filter(
+    (p) => p.name !== 'index' && p.frontMatter?.date
+  )
+
+  return (
+    <div className="ct-blog-grid">
+      {articles.map((a) => (
+        <a key={a.name} href={a.route} className="ct-blog-card">
+          {a.frontMatter?.cover && (
+            <img
+              src={a.frontMatter.cover}
+              alt=""
+              className="ct-blog-card-cover"
+            />
+          )}
+          <div className="ct-blog-card-body">
+            <h3 className="ct-blog-card-title">{a.frontMatter?.title}</h3>
+            <p className="ct-blog-card-meta">
+              {a.frontMatter?.date &&
+                new Date(a.frontMatter.date).toLocaleDateString('en-US', {
+                  month: 'short',
+                  day: 'numeric',
+                  year: 'numeric'
+                })}
+              {a.frontMatter?.readingTime &&
+                ` · ${a.frontMatter.readingTime} min read`}
+            </p>
+            {a.frontMatter?.description && (
+              <p className="ct-blog-card-desc">{a.frontMatter.description}</p>
+            )}
+          </div>
+        </a>
+      ))}
+    </div>
+  )
+}

--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -44,7 +44,7 @@ body > [class*="bg-gray-100"] {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 1.5rem;
-  margin-top: 0.5rem;
+  margin-top: 3rem;
   clear: both;
 }
 

--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -42,9 +42,16 @@ body > [class*="bg-gray-100"] {
 
 .ct-blog-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-template-columns: repeat(2, 1fr);
   gap: 1.5rem;
-  margin-top: 1.5rem;
+  margin-top: 0.5rem;
+  clear: both;
+}
+
+@media (max-width: 640px) {
+  .ct-blog-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .ct-blog-card {

--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -38,6 +38,74 @@ body > [class*="bg-gray-100"] {
   margin: 0 0 1.5rem 0;
 }
 
+/* Blog card grid -------------------------------------------------------- */
+
+.ct-blog-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.ct-blog-card {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  text-decoration: none;
+  color: inherit;
+  transition: box-shadow 150ms ease, border-color 150ms ease;
+  display: flex;
+  flex-direction: column;
+}
+
+.ct-blog-card:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  border-color: rgba(0, 0, 0, 0.15);
+}
+
+html.dark .ct-blog-card {
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+html.dark .ct-blog-card:hover {
+  border-color: rgba(255, 255, 255, 0.2);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.ct-blog-card-cover {
+  width: 100%;
+  aspect-ratio: 2.38 / 1;
+  object-fit: cover;
+}
+
+.ct-blog-card-body {
+  padding: 1rem;
+}
+
+.ct-blog-card-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin: 0 0 0.375rem 0;
+  line-height: 1.3;
+}
+
+.ct-blog-card-meta {
+  font-size: 0.8rem;
+  opacity: 0.55;
+  margin: 0 0 0.5rem 0;
+}
+
+.ct-blog-card-desc {
+  font-size: 0.875rem;
+  opacity: 0.75;
+  margin: 0;
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 /* Footer content -------------------------------------------------------- */
 
 .ct-footer-inner {

--- a/docs/content/blog/_meta.ts
+++ b/docs/content/blog/_meta.ts
@@ -19,6 +19,5 @@ export default {
   },
   'videos-graphql-api-with-appsync-lambda-dynamodb': {
     title: 'Videos GraphQL API - CodeTube #6'
-  },
-  index: { display: 'hidden' }
+  }
 }

--- a/docs/content/blog/application-shell-using-nextjs-material-ui-amplify-hosting.mdx
+++ b/docs/content/blog/application-shell-using-nextjs-material-ui-amplify-hosting.mdx
@@ -3,6 +3,8 @@ title: "Application Shell using Next.js, Material UI, Amplify Hosting - CodeTube
 date: 2025-07-16
 description: "We are finally ready to start coding. In the last two episodes we finalised important prerequisites -..."
 source: "https://dev.to/jacekkosciesza/application-shell-using-nextjs-material-ui-amplify-hosting-faketube-3-1ig8"
+cover: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2F2si10may093lkm746w8f.png"
+readingTime: 20
 ---
 
 

--- a/docs/content/blog/build-youtube-clone-with-aws.mdx
+++ b/docs/content/blog/build-youtube-clone-with-aws.mdx
@@ -3,6 +3,8 @@ title: "Build YouTube Clone with AWS - CodeTube #0"
 date: 2023-03-31
 description: "I'm a builder. For over a year I've been building a project which is a YouTube clone called..."
 source: "https://dev.to/aws-builders/build-youtube-clone-with-aws-faketube-1-2odo"
+cover: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fs0sudmaej619vaj5fblu.png"
+readingTime: 16
 ---
 
 I'm a builder. For over a year I've been building a project which is a **YouTube clone** called **CodeTube**.

--- a/docs/content/blog/generative-ai-videos-using-bedrock-polly-imovie.mdx
+++ b/docs/content/blog/generative-ai-videos-using-bedrock-polly-imovie.mdx
@@ -3,6 +3,8 @@ title: "Generative AI Videos using Bedrock, Polly, iMovie - CodeTube #2"
 date: 2025-03-31
 description: "We are building CodeTube - a YouTube clone using cloud-native and web technologies. In the last..."
 source: "https://dev.to/aws-builders/generative-ai-videos-using-bedrock-polly-imovie-faketube-2-28mm"
+cover: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fpw717u503ramiz8tnq5k.png"
+readingTime: 34
 ---
 
 We are building **CodeTube - a YouTube clone** using cloud-native and web technologies. In the last episode we defined initial project requirements. We are almost ready for the development, but before we jump into writing code, **we need one more thing - a video content**.

--- a/docs/content/blog/home-page-using-nextjs-material-ui-tanstack-query.mdx
+++ b/docs/content/blog/home-page-using-nextjs-material-ui-tanstack-query.mdx
@@ -3,6 +3,8 @@ title: "Home Page using Next.js, Material UI, TanStack Query - CodeTube #4"
 date: 2025-07-29
 description: "Let's add a video content to our YouTube clone. In the last episode we created a static app shell..."
 source: "https://dev.to/jacekkosciesza/home-page-using-nextjs-material-ui-tanstack-query-faketube-4-485"
+cover: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fgfi81xi2n1cecmdj9xn2.png"
+readingTime: 17
 ---
 
 Let's add a **video content** to our YouTube clone. In the last episode we created a static app shell with a basic branding and navigation. It's time to create a more dynamic part - **home page** with a **responsive grid of media items**. 

--- a/docs/content/blog/index.mdx
+++ b/docs/content/blog/index.mdx
@@ -2,5 +2,9 @@
 title: Blog
 ---
 
-Articles from the [dev.to series](https://dev.to/jacekkosciesza/series/22439)
-will land here. Each post gets its own MDX file under `content/blog/`.
+import { BlogCards } from '../../app/_components/BlogCards'
+
+A 7-part tutorial series on building a YouTube clone with AWS, Next.js,
+Material UI, and more.
+
+<BlogCards />

--- a/docs/content/blog/index.mdx
+++ b/docs/content/blog/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Blog
+hideTitle: true
 ---
 
 import { BlogCards } from '../../app/_components/BlogCards'

--- a/docs/content/blog/index.mdx
+++ b/docs/content/blog/index.mdx
@@ -1,11 +1,9 @@
 ---
 title: Blog
 hideTitle: true
+asIndexPage: true
 ---
 
 import { BlogCards } from '../../app/_components/BlogCards'
-
-A 7-part tutorial series on building a YouTube clone with AWS, Next.js,
-Material UI, and more.
 
 <BlogCards />

--- a/docs/content/blog/initial-requirements-using-gherkin-github-codecatalyst.mdx
+++ b/docs/content/blog/initial-requirements-using-gherkin-github-codecatalyst.mdx
@@ -3,6 +3,8 @@ title: "Initial Requirements using Gherkin, GitHub, CodeCatalyst - CodeTube #1"
 date: 2025-03-31
 description: "We are building CodeTube - a YouTube clone software engineering project using cloud-native and web..."
 source: "https://dev.to/aws-builders/initial-requirements-using-gherkin-github-codecatalyst-faketube-1-3087"
+cover: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2F0zvv4tqqhh3q9jmu3nvo.png"
+readingTime: 18
 ---
 
 We are building **CodeTube - a YouTube clone** software engineering project using cloud-native and web technologies. As a first step we have to **define our vision and project requirements**. 

--- a/docs/content/blog/videos-graphql-api-with-appsync-lambda-dynamodb.mdx
+++ b/docs/content/blog/videos-graphql-api-with-appsync-lambda-dynamodb.mdx
@@ -3,6 +3,8 @@ title: "Videos GraphQL API with AppSync, Lambda, DynamoDB - CodeTube #6"
 date: 2025-10-02
 description: "CodeTube  In the last episode, we established a solid backend foundation using a traditional REST API..."
 source: "https://dev.to/jacekkosciesza/videos-graphql-api-with-appsync-lambda-dynamodb-faketube-6-2jcb"
+cover: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2F1avzf8va1fmbv91yrnp5.png"
+readingTime: 28
 ---
 
 [CodeTube](https://faketube.app/)

--- a/docs/content/blog/videos-rest-api-with-api-gateway-lambda-aurora-serverless.mdx
+++ b/docs/content/blog/videos-rest-api-with-api-gateway-lambda-aurora-serverless.mdx
@@ -3,6 +3,8 @@ title: "Videos REST API with API Gateway, Lambda, Aurora Serverless - CodeTube #
 date: 2025-08-23
 description: "faketube.app  In the previous episodes, we created a solid frontend foundation for our project -..."
 source: "https://dev.to/jacekkosciesza/videos-rest-api-with-api-gateway-lambda-aurora-serverless-faketube-5-1102"
+cover: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fdhjiby7rdazudyfkbuun.png"
+readingTime: 38
 ---
 
 [faketube.app](https://faketube.app/)


### PR DESCRIPTION
## Summary

Replaces the placeholder blog index with a card grid showing each article's **cover image**, **title**, **date**, **reading time**, and **description excerpt** — similar to how dev.to renders the series page.

### Files

- **`app/_components/BlogCards.tsx`** — async server component that reads Nextra's `getPageMap('/blog')` to get article frontmatter, then renders a responsive 2-column card grid. Each card links to the full article.
- **`content/blog/index.mdx`** — imports and renders `<BlogCards />` with a short intro paragraph.
- **All 7 article MDX files** — added `cover` (dev.to CDN URL) and `readingTime` (minutes) to frontmatter, re-fetched from the dev.to API.
- **`globals.css`** — card grid styles: responsive grid, hover shadow/border, cover image aspect ratio, meta line, truncated description. Light + dark variants.

## Test plan

- [x] `npm run build -w docs` succeeds
- [x] Playwright screenshots of `/blog` in light + dark — 7 article cards render with cover images, all in series order
- [ ] Reviewer: pull branch, `npm run dev -w docs`, open http://localhost:3000/blog — confirm cards render, cover images load, clicking a card navigates to the article

Follow-up if wanted: article header metadata (date + reading time at the top of each article page).