### PR TITLE
chore(cloud): bump CDK to latest (2.257.0 / CLI 2.1124.1)

### DIFF
--- a/cloud/package.json
+++ b/cloud/package.json
@@ -18,7 +18,7 @@
     "@types/aws-lambda": "^8.10.152",
     "@types/jest": "^29.5.14",
     "@types/node": "22.7.9",
-    "aws-cdk": "2.1025.0",
+    "aws-cdk": "2.1124.1",
     "esbuild": "^0.25.9",
     "graphql-schema-utilities": "^1.1.8",
     "jest": "^29.7.0",
@@ -35,7 +35,7 @@
     "@middy/http-cors": "^6.4.3",
     "@middy/http-error-handler": "^6.4.3",
     "@middy/validator": "^6.4.3",
-    "aws-cdk-lib": "2.208.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "^10.0.0",
     "data-api-client": "^2.0.0-beta.0",
     "middy-env": "^2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,13 +25,13 @@
         "@middy/http-cors": "^6.4.3",
         "@middy/http-error-handler": "^6.4.3",
         "@middy/validator": "^6.4.3",
-        "aws-cdk-lib": "2.208.0",
+        "aws-cdk-lib": "2.257.0",
         "constructs": "^10.0.0",
         "data-api-client": "^2.0.0-beta.0",
         "middy-env": "^2.0.0"
       },
       "bin": {
-        "faketube": "bin/faketube.js"
+        "codetube": "bin/codetube.js"
       },
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "^3.894.0",
@@ -39,7 +39,7 @@
         "@types/aws-lambda": "^8.10.152",
         "@types/jest": "^29.5.14",
         "@types/node": "22.7.9",
-        "aws-cdk": "2.1025.0",
+        "aws-cdk": "2.1124.1",
         "esbuild": "^0.25.9",
         "graphql-schema-utilities": "^1.1.8",
         "jest": "^29.7.0",
@@ -69,13 +69,18 @@
     },
     "docs/node_modules/@types/node": {
       "version": "20.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
-      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "docs/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@antfu/install-pkg": {
       "version": "1.1.0",
@@ -283,9 +288,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.242",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.242.tgz",
-      "integrity": "sha512-4c1bAy2ISzcdKXYS1k4HYZsNrgiwbiDzj36ybwFVxEWZXVAP0dimQTCaB9fxu7sWzEjw3d+eaw6Fon+QTfTIpQ==",
+      "version": "2.2.273",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
+      "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
@@ -295,24 +300,24 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "45.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-45.2.0.tgz",
-      "integrity": "sha512-5TTUkGHQ+nfuUGwKA8/Yraxb+JdNUh4np24qk/VHXmrCMq+M6HfmGWfhcg/QlHA2S5P3YIamfYHdQAB4uSNLAg==",
+      "version": "53.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.27.0.tgz",
+      "integrity": "sha512-OTxe/L2Vc60r2nYih7kFaFpn93sa7shJu9T0tQZsryeDE3HHOAuazKNmS6tLInOjJjVx/dvM5XGyUA+lZAiKxA==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.2"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -320,7 +325,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.2",
+      "version": "7.8.0",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -5556,12 +5561,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "node_modules/@types/node/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
-    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -6770,9 +6769,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1025.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1025.0.tgz",
-      "integrity": "sha512-qKYM+RG5+U/UbGpjTt8ZaxBEfKJMPdOmtPtFNidsIGlrdIWSIFdNcFYi13zo33FkMk6ZFA6yBnjfDry3fNR+hQ==",
+      "version": "2.1124.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1124.1.tgz",
+      "integrity": "sha512-sRYdPMdkX+02EHaT946AFV0w0CMfbHKWpLZPv525xTCkaVu1eYu6DzHFuTdimxdSN0uGQ2D4LHrD1sr94tRhow==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6780,17 +6779,15 @@
       },
       "engines": {
         "node": ">= 18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.208.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.208.0.tgz",
-      "integrity": "sha512-lZW475enKz36A/hZvS7xUwfjeqLqxKgBmZ2cGA7BB5PAlQsjBfN70ZGDgGl0egug5fb/hsYy1Dy4OrclfNzxFg==",
+      "version": "2.257.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz",
+      "integrity": "sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==",
       "bundleDependencies": [
         "@balena/dockerignore",
+        "@aws-cdk/cloud-assembly-api",
         "case",
         "fs-extra",
         "ignore",
@@ -6804,26 +6801,53 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.242",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^45.2.0",
+        "@aws-cdk/asset-awscli-v1": "2.2.273",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
+        "@aws-cdk/cloud-assembly-api": "^2.2.4",
+        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.0",
+        "fs-extra": "^11.3.3",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
-        "minimatch": "^3.1.2",
+        "minimatch": "^10.2.3",
         "punycode": "^2.3.1",
-        "semver": "^7.7.2",
+        "semver": "^7.7.4",
         "table": "^6.9.0",
-        "yaml": "1.10.2"
+        "yaml": "1.10.3"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "constructs": "^10.0.0"
+        "constructs": "^10.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.2.4",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+      "version": "7.8.0",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -6832,7 +6856,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.17.1",
+      "version": "8.18.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6877,17 +6901,22 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
-      "version": "1.0.2",
+      "version": "4.0.4",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "5.0.5",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
@@ -6914,11 +6943,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/aws-cdk-lib/node_modules/concat-map": {
-      "version": "0.0.1",
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
       "version": "8.0.0",
       "inBundle": true,
@@ -6930,7 +6954,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.0.6",
+      "version": "3.1.2",
       "funding": [
         {
           "type": "github",
@@ -6945,7 +6969,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.0",
+      "version": "11.3.3",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6984,7 +7008,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.1.0",
+      "version": "6.2.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7027,14 +7051,17 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "10.2.5",
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
@@ -7054,7 +7081,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.2",
+      "version": "7.7.4",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -7128,7 +7155,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
-      "version": "1.10.2",
+      "version": "1.10.3",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -7327,7 +7354,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -7385,7 +7411,6 @@
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
       "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -8007,7 +8032,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/constant-case": {
@@ -9203,9 +9227,9 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
-      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
       "license": "MIT",
       "workspaces": [
         "docs",
@@ -10212,9 +10236,10 @@
       "license": "ISC"
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -10671,6 +10696,43 @@
         "subscriptions-transport-ws": {
           "optional": true
         }
+      }
+    },
+    "node_modules/graphql-tools/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/graphql-tools/node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/graphql-tools/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/hachure-fill": {
@@ -11174,7 +11236,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -14137,7 +14198,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -15189,6 +15249,20 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/points-on-curve": {
@@ -17555,10 +17629,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -18331,6 +18404,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "web/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }


### PR DESCRIPTION
Prerequisite for adding Amplify Hosting constructs in the next PR.

- \`aws-cdk-lib\`: 2.208.0 → 2.257.0
- \`aws-cdk\` (CLI): 2.1025.0 → 2.1124.1

Tests pass, \`cdk synth\` produces valid CloudFormation.