### PR TITLE
feat(cloud): add DocsStack for Amplify Hosting of docs site

### DIFF
--- a/cloud/bin/codetube.ts
+++ b/cloud/bin/codetube.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import { CodeTubeStack } from "../lib/codetube-stack";
+import { DocsStack } from "../lib/docs-stack";
 
 const app = new cdk.App();
 new CodeTubeStack(app, "FakeTubeStack", {
@@ -18,3 +19,5 @@ new CodeTubeStack(app, "FakeTubeStack", {
 
   /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
 });
+
+new DocsStack(app, "DocsStack");

--- a/cloud/lib/docs-stack.ts
+++ b/cloud/lib/docs-stack.ts
@@ -1,0 +1,63 @@
+import * as cdk from "aws-cdk-lib";
+import * as codebuild from "aws-cdk-lib/aws-codebuild";
+import * as amplify from "@aws-cdk/aws-amplify-alpha";
+import { Construct } from "constructs";
+
+export class DocsStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const amplifyApp = new amplify.App(this, "DocsApp", {
+      appName: "codetube-docs",
+      sourceCodeProvider: new amplify.GitHubSourceCodeProvider({
+        owner: "JacekKosciesza",
+        repository: "CodeTube",
+        oauthToken: cdk.SecretValue.secretsManager("github-token"),
+      }),
+      platform: amplify.Platform.WEB_COMPUTE,
+      buildSpec: codebuild.BuildSpec.fromObjectToYaml({
+        version: "1",
+        frontend: {
+          phases: {
+            preBuild: {
+              commands: ["npm ci"],
+            },
+            build: {
+              commands: ["npm run build -w docs"],
+            },
+          },
+          artifacts: {
+            baseDirectory: "docs/.next",
+            files: ["**/*"],
+          },
+          cache: {
+            paths: ["node_modules/**/*"],
+          },
+        },
+      }),
+    });
+
+    const mainBranch = amplifyApp.addBranch("main", {
+      autoBuild: true,
+      stage: "PRODUCTION",
+    });
+
+    amplifyApp.addDomain("codetube.org", {
+      subDomains: [
+        { branch: mainBranch, prefix: "" },
+        { branch: mainBranch, prefix: "www" },
+      ],
+    });
+
+    new cdk.CfnOutput(this, "AmplifyAppId", {
+      value: amplifyApp.appId,
+      description: "Amplify App ID for the docs site",
+    });
+
+    new cdk.CfnOutput(this, "AmplifyDefaultDomain", {
+      value: `main.${amplifyApp.defaultDomain}`,
+      description:
+        "Default Amplify domain (usable before custom domain is verified)",
+    });
+  }
+}

--- a/cloud/package.json
+++ b/cloud/package.json
@@ -27,6 +27,7 @@
     "typescript": "~5.6.3"
   },
   "dependencies": {
+    "@aws-cdk/aws-amplify-alpha": "^2.257.0-alpha.0",
     "@aws-lambda-powertools/logger": "^2.25.1",
     "@aws-lambda-powertools/metrics": "^2.25.1",
     "@aws-lambda-powertools/tracer": "^2.25.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       "name": "@codetube/cloud",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-cdk/aws-amplify-alpha": "^2.257.0-alpha.0",
         "@aws-lambda-powertools/logger": "^2.25.1",
         "@aws-lambda-powertools/metrics": "^2.25.1",
         "@aws-lambda-powertools/tracer": "^2.25.1",
@@ -298,6 +299,19 @@
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
       "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/aws-amplify-alpha": {
+      "version": "2.257.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-amplify-alpha/-/aws-amplify-alpha-2.257.0-alpha.0.tgz",
+      "integrity": "sha512-UF6QZhrbIqpgn1wtU9J7Nh7Hs13R9W4VijwE7e2jTkFAhN5NEQv0/FnV0WlxlFIMquwoH4Io6B5I91jVpNyZ8A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.257.0",
+        "constructs": "^10.5.0"
+      }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
       "version": "53.27.0",
@@ -7354,6 +7368,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -7411,6 +7426,7 @@
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
       "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -8032,6 +8048,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/constant-case": {
@@ -10698,43 +10715,6 @@
         }
       }
     },
-    "node_modules/graphql-tools/node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/graphql-tools/node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "node_modules/graphql-tools/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
     "node_modules/hachure-fill": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
@@ -11236,6 +11216,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -14198,6 +14179,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"


### PR DESCRIPTION
## Summary

New CDK stack (\`DocsStack\`) that deploys the Nextra docs site to AWS Amplify Hosting at \`codetube.org\`.

### What it creates
- **Amplify App** — GitHub-connected to \`JacekKosciesza/CodeTube\`, auto-builds on push to \`main\`
- **Branch** — \`main\` (production stage)
- **Custom domain** — \`codetube.org\` + \`www.codetube.org\`
- **Platform** — \`WEB_COMPUTE\` (Next.js SSG support)

### Build spec
Runs from repo root (monorepo):
1. \`npm ci\` — installs all workspaces
2. \`npm run build -w docs\` — next build + pagefind postbuild
3. Artifacts from \`docs/.next\`

### To deploy

**Step 1:** Store a GitHub personal access token in Secrets Manager:
\`\`\`bash
aws secretsmanager create-secret --name github-token --secret-string "ghp_YOUR_TOKEN_HERE"
\`\`\`
Token needs \`repo\` scope (classic PAT).

**Step 2:** Deploy the stack:
\`\`\`bash
cd cloud
npx cdk deploy DocsStack
\`\`\`

**Step 3:** Configure DNS in GoDaddy — Amplify will provide CNAME records for domain verification. Add them in GoDaddy's DNS settings.

### Outputs
- \`AmplifyAppId\` — for console reference
- \`AmplifyDefaultDomain\` — usable before custom domain is verified

## Test plan
- [x] \`npx cdk synth DocsStack\` produces valid CloudFormation
- [x] \`npm test -w cloud\` passes
- [ ] Actual deploy (\`cdk deploy DocsStack\`) — requires GitHub token in Secrets Manager