### PR TITLE
fix(docs): switch to static export for Amplify Hosting

### DIFF
--- a/cloud/lib/docs-stack.ts
+++ b/cloud/lib/docs-stack.ts
@@ -14,7 +14,7 @@ export class DocsStack extends cdk.Stack {
         repository: "CodeTube",
         oauthToken: cdk.SecretValue.secretsManager("github-token"),
       }),
-      platform: amplify.Platform.WEB_COMPUTE,
+      platform: amplify.Platform.WEB,
       buildSpec: codebuild.BuildSpec.fromObjectToYaml({
         version: "1",
         frontend: {
@@ -27,7 +27,7 @@ export class DocsStack extends cdk.Stack {
             },
           },
           artifacts: {
-            baseDirectory: "docs/.next",
+            baseDirectory: "docs/out",
             files: ["**/*"],
           },
           cache: {
@@ -43,10 +43,7 @@ export class DocsStack extends cdk.Stack {
     });
 
     amplifyApp.addDomain("codetube.org", {
-      subDomains: [
-        { branch: mainBranch, prefix: "" },
-        { branch: mainBranch, prefix: "www" },
-      ],
+      subDomains: [{ branch: mainBranch, prefix: "" }],
     });
 
     new cdk.CfnOutput(this, "AmplifyAppId", {

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -3,6 +3,8 @@ import nextra from 'nextra'
 const withNextra = nextra({})
 
 export default withNextra({
+  output: 'export',
+  images: { unoptimized: true },
   reactStrictMode: true,
   devIndicators: false
 })

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "postbuild": "pagefind --site .next/server/app --output-path public/_pagefind",
+    "postbuild": "pagefind --site out --output-path out/_pagefind",
     "start": "next start"
   },
   "dependencies": {


### PR DESCRIPTION
Amplify \`WEB_COMPUTE\` expected a \`deploy-manifest.json\` that Next.js doesn't produce without an adapter. Since the docs site is fully SSG, switch to static export.

**Changes:**
- \`next.config.mjs\`: \`output: 'export'\` + \`images: { unoptimized: true }\`
- \`package.json\`: pagefind postbuild indexes \`out/\` directly
- \`docs-stack.ts\`: platform \`WEB\`, baseDirectory \`docs/out\`, dropped \`www\` subdomain

**After merge:** \`cd cloud && npx cdk deploy DocsStack\` to update the Amplify app config, then Amplify will auto-rebuild from main.