### PR TITLE
feat(cloud): add WebStack for web app Amplify Hosting

### DIFF
--- a/cloud/bin/codetube.ts
+++ b/cloud/bin/codetube.ts
@@ -2,6 +2,7 @@
 import * as cdk from 'aws-cdk-lib';
 import { CodeTubeStack } from "../lib/codetube-stack";
 import { DocsStack } from "../lib/docs-stack";
+import { WebStack } from "../lib/web-stack";
 
 const app = new cdk.App();
 new CodeTubeStack(app, "FakeTubeStack", {
@@ -21,3 +22,4 @@ new CodeTubeStack(app, "FakeTubeStack", {
 });
 
 new DocsStack(app, "DocsStack");
+new WebStack(app, "WebStack");

--- a/cloud/lib/web-stack.ts
+++ b/cloud/lib/web-stack.ts
@@ -1,0 +1,64 @@
+import * as cdk from "aws-cdk-lib";
+import * as codebuild from "aws-cdk-lib/aws-codebuild";
+import * as amplify from "@aws-cdk/aws-amplify-alpha";
+import { Construct } from "constructs";
+
+export class WebStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const amplifyApp = new amplify.App(this, "WebApp", {
+      appName: "codetube-web",
+      sourceCodeProvider: new amplify.GitHubSourceCodeProvider({
+        owner: "JacekKosciesza",
+        repository: "CodeTube",
+        oauthToken: cdk.SecretValue.secretsManager("github-token"),
+      }),
+      platform: amplify.Platform.WEB_COMPUTE,
+      buildSpec: codebuild.BuildSpec.fromObjectToYaml({
+        version: "1",
+        applications: [
+          {
+            appRoot: "web",
+            frontend: {
+              phases: {
+                preBuild: {
+                  commands: ["cd ..", "npm ci"],
+                },
+                build: {
+                  commands: ["cd ..", "npm run build -w web"],
+                },
+              },
+              artifacts: {
+                baseDirectory: ".next",
+                files: ["**/*"],
+              },
+              cache: {
+                paths: ["node_modules/**/*"],
+              },
+            },
+          },
+        ],
+      }),
+    });
+
+    const mainBranch = amplifyApp.addBranch("main", {
+      autoBuild: true,
+      stage: "PRODUCTION",
+    });
+
+    amplifyApp.addDomain("codetube.app", {
+      subDomains: [{ branch: mainBranch, prefix: "" }],
+    });
+
+    new cdk.CfnOutput(this, "AmplifyAppId", {
+      value: amplifyApp.appId,
+      description: "Amplify App ID for the web app",
+    });
+
+    new cdk.CfnOutput(this, "AmplifyDefaultDomain", {
+      value: `main.${amplifyApp.defaultDomain}`,
+      description: "Default Amplify domain",
+    });
+  }
+}


### PR DESCRIPTION
Replaces the manually-created Amplify app (broken compute role) with a CDK-managed stack.

**After merge:**
1. \`cd cloud && npx cdk deploy WebStack\`
2. Delete old app (\`d1nklz39b18tpf\`) from Amplify console — must remove its \`codetube.app\` domain first
3. New app auto-builds from main with proper SSR compute role