### PR TITLE
fix(cloud): use appRoot + cd && for web build spec

### DIFF
--- a/cloud/lib/web-stack.ts
+++ b/cloud/lib/web-stack.ts
@@ -17,23 +17,28 @@ export class WebStack extends cdk.Stack {
       platform: amplify.Platform.WEB_COMPUTE,
       buildSpec: codebuild.BuildSpec.fromObjectToYaml({
         version: "1",
-        frontend: {
-          phases: {
-            preBuild: {
-              commands: ["npm ci"],
+        applications: [
+          {
+            appRoot: "web",
+            frontend: {
+              phases: {
+                preBuild: {
+                  commands: ["cd .. && npm ci"],
+                },
+                build: {
+                  commands: ["cd .. && npm run build -w web"],
+                },
+              },
+              artifacts: {
+                baseDirectory: ".next",
+                files: ["**/*"],
+              },
+              cache: {
+                paths: ["../node_modules/**/*"],
+              },
             },
-            build: {
-              commands: ["npm run build -w web"],
-            },
           },
-          artifacts: {
-            baseDirectory: "web/.next",
-            files: ["**/*"],
-          },
-          cache: {
-            paths: ["node_modules/**/*"],
-          },
-        },
+        ],
       }),
     });
 


### PR DESCRIPTION
Amplify needs appRoot: web to detect Next.js and generate the deploy manifest. Combined cd with && so directory changes persist. After merge: cdk deploy WebStack + retrigger build.