### PR TITLE
fix(cloud): run next build from appRoot directly

### DIFF
--- a/cloud/lib/web-stack.ts
+++ b/cloud/lib/web-stack.ts
@@ -26,7 +26,7 @@ export class WebStack extends cdk.Stack {
                   commands: ["cd .. && npm ci"],
                 },
                 build: {
-                  commands: ["cd .. && npm run build -w web"],
+                  commands: ["npx next build"],
                 },
               },
               artifacts: {


### PR DESCRIPTION
Stop fighting cd between phases. npx next build runs from web/ (appRoot) and Node resolves packages from root. After merge: cdk deploy WebStack + retrigger.