### PR TITLE
fix(cloud): match docs-style build spec for web app

### DIFF
--- a/cloud/lib/web-stack.ts
+++ b/cloud/lib/web-stack.ts
@@ -17,28 +17,23 @@ export class WebStack extends cdk.Stack {
       platform: amplify.Platform.WEB_COMPUTE,
       buildSpec: codebuild.BuildSpec.fromObjectToYaml({
         version: "1",
-        applications: [
-          {
-            appRoot: "web",
-            frontend: {
-              phases: {
-                preBuild: {
-                  commands: ["npm ci --prefix .."],
-                },
-                build: {
-                  commands: ["npx next build"],
-                },
-              },
-              artifacts: {
-                baseDirectory: ".next",
-                files: ["**/*"],
-              },
-              cache: {
-                paths: ["../node_modules/**/*"],
-              },
+        frontend: {
+          phases: {
+            preBuild: {
+              commands: ["npm ci"],
+            },
+            build: {
+              commands: ["npm run build -w web"],
             },
           },
-        ],
+          artifacts: {
+            baseDirectory: "web/.next",
+            files: ["**/*"],
+          },
+          cache: {
+            paths: ["node_modules/**/*"],
+          },
+        },
       }),
     });
 


### PR DESCRIPTION
Drop appRoot. Same flat spec as working docs app.